### PR TITLE
Migrate pattern DSL core to open code style

### DIFF
--- a/list_unrolling/lib/utilities/pat_playground/pat_playground.ml
+++ b/list_unrolling/lib/utilities/pat_playground/pat_playground.ml
@@ -4,19 +4,19 @@ module Examples(P : module type of Fcpatterns.Pat) = struct
   open P
 
   let[@warning "-32"] f : (int * int -> int) code = function_ [
-      (var   ** int 4) => .< fun x -> x + 1 >.; 
+      (var   ** int 4) => (fun x -> .<.~x + 1 >.); 
       (int 3 ** __   ) => .< 1 >.             ;
-      (var   ** var  ) => .< fun x -> fun y -> x + y >.
+      (var   ** var  ) => fun x y -> .<.~x + .~y>.
     ]
   let[@warning "-32"] pairs_example : (int  * int -> int) code = .<let f = .~(function_ [
     __    ** int 2   => .< 1 >. ;
     (int 3 ** __)    => .< 1 >. ;
-    (var   ** var)   => .< fun a b -> a + b >.;
+    (var   ** var)   => fun a b -> .< .~a + .~b >.;
     ]) in f>.
 
   let[@warning "-32"] list_example : ('a list -> 'a list) code = .<let f = .~(function_ [
     empty       => .< [] >. ;
-    var >:: var => .<fun _ xs -> xs>.
+    var >:: var => fun _ xs -> xs
   ]) in f>.
 
   (* Due to OCaml's restrictions on the RHS of let recs, a let rec RHS cannot be a direct quote of code. In cases
@@ -34,16 +34,16 @@ module Examples(P : module type of Fcpatterns.Pat) = struct
      See https://ocaml.org/manual/5.1/letrecvalues.html for discussion of these RHS restrictions *)
   let[@warning "-32"] length_example : ('a list -> int) code = .<let rec len _ = .~(function_ [
     empty       => .< 0 >. ;
-    var >:: var => .<fun _ xs -> 1 + len () xs>.
+    var >:: var => fun _ xs -> .<1 + len () .~xs>.
   ]) in len ()>.
 
   let[@warning "-32"] match_length_example : ('a list -> int) code = .<let rec len l = .~(match_ .<l>. [
     empty       => .< 0 >. ;
-    var >:: var => .<fun _ xs -> 1 + len xs>.
+    var >:: var => fun _ xs -> .<1 + len .~xs>.
   ]) in len>.
   let[@warning "-32"] nmap_example = .<let rec nmap f = .~(function_ [
     empty       => .<[]>.;
-    var >:: var => .<fun x xs -> let y = f x in y :: nmap f xs>.
+    var >:: var => fun x xs -> .<let y = f .~x in y :: nmap f .~xs>.
   ]) in nmap>.;;
 end
 

--- a/list_unrolling/lib/utilities/patterns/common.ml
+++ b/list_unrolling/lib/utilities/patterns/common.ml
@@ -4,7 +4,7 @@ open Trx
 type (_, _, _) pat =
     Any : ('a, 'r, 'r) pat
   | Int : int -> (int, 'r, 'r) pat
-  | Var : ('a, 'a -> 'r, 'r) pat
+  | Var : ('a, 'a code -> 'r, 'r) pat
   | EmptyList : ('a, 'r, 'r) pat
   | Pair : ('a, 'k, 'j) pat * ('b, 'j, 'r) pat -> ('a * 'b, 'k, 'r) pat
   | Cons : ('a, 'k, 'j) pat * ('a list, 'j, 'r) pat -> ('a list, 'k, 'r) pat

--- a/list_unrolling/lib/utilities/patterns/common.mli
+++ b/list_unrolling/lib/utilities/patterns/common.mli
@@ -1,7 +1,7 @@
 type (_, _, _) pat =
     Any : ('a, 'r, 'r) pat
   | Int : int -> (int, 'r, 'r) pat
-  | Var : ('a, 'a -> 'r, 'r) pat
+  | Var : ('a, 'a Trx.code -> 'r, 'r) pat
   | EmptyList : ('a, 'r, 'r) pat
   | Pair : ('a, 'k, 'j) pat * ('b, 'j, 'r) pat -> ('a * 'b, 'k, 'r) pat
   | Cons : ('a, 'k, 'j) pat * ('a list, 'j, 'r) pat -> ('a list, 'k, 'r) pat

--- a/list_unrolling/lib/utilities/patterns/dune
+++ b/list_unrolling/lib/utilities/patterns/dune
@@ -1,6 +1,6 @@
 (library
  (name fcpatterns)
- (libraries dynlink metaocaml fun_rebind)
+ (libraries dynlink metaocaml)
  (modules fcpatterns common pat unsafe))
 
 ; (env

--- a/list_unrolling/lib/utilities/patterns/pat.mli
+++ b/list_unrolling/lib/utilities/patterns/pat.mli
@@ -8,7 +8,7 @@ val __ : ('a, 'r, 'r) pat
 val int : int -> (int, 'r, 'r) pat
 
 (* Variable binding pattern *)
-val var : ('a, 'a -> 'r, 'r) pat
+val var : ('a, 'a code -> 'r, 'r) pat
 
 (* Binary tuple pattern *)
 val ( ** ) : ('a, 'k, 'j) pat -> ('b, 'j, 'r) pat -> ('a * 'b, 'k, 'r) pat
@@ -19,7 +19,7 @@ val ( >:: ) : ('a, 'k, 'j) pat -> ('a list, 'j, 'r) pat -> ('a list, 'k, 'r) pat
 
 (* Pattern - function case pairs *)
 type (_, _) case
-val (=>) :('a, 'f, 'r) pat -> 'f code -> ('a, 'r) case
+val (=>) : ('a, 'f, 'r code) pat -> 'f -> ('a, 'r) case
 
 (* Function generator *)
 val function_ : ('a, 'b) case list -> ('a -> 'b) code
@@ -29,4 +29,4 @@ val match_ : ('a code) -> ('a, 'b) case list -> 'b code
 
 (* Safe first-class pattern generation *)
 
-type ('a, 'r) patwrap = Pat : ('a list, 'f, 'r) pat * (('r code -> 'r code) -> 'f code) -> ('a, 'r) patwrap
+type ('a, 'r) patwrap = Pat : ('a list, 'f, 'r code) pat * (('r code -> 'r code) -> 'f) -> ('a, 'r) patwrap

--- a/list_unrolling/lib/utilities/patterns/unsafe.ml
+++ b/list_unrolling/lib/utilities/patterns/unsafe.ml
@@ -1,7 +1,3 @@
-open Codelib;;
-open Fun_rebind;;
-open Common;;
-
 type ('a, 'f, 'r) pat = ('a, 'f, 'r) Pat.pat
 
 (* Unsafe first-class pattern generation *)
@@ -11,12 +7,18 @@ type ('a, 'r) unsafe_pat = ('a, unit, 'r) Pat.pat
 let unsafe_loosen (p : ('a, 'f, 'r) pat) : ('a, 'r) unsafe_pat = Obj.magic p
 let unsafe_tighten (p : ('a, 'r) unsafe_pat) : ('a, 'f, 'r) pat = Obj.magic p
 
-(* Safe-wrapped unsafe first-class pattern generation *)
+(* Safe-wrapped unsafe first-class pattern generation
 
-type ('a, 'r) unsafe_patwrap = Pat : ('a list, 'f, 'r) pat * 'f code -> ('a, 'r) unsafe_patwrap
+This unsafe approach is not possible without near-complete redesign after migration to the (=>) operator taking an 'f
+instead of an 'f code, as the inner expression can no longer be unsafely accessed without applying values to the built
+up function .
+
+type ('a, 'r) unsafe_patwrap = UPat : ('a list, 'f, 'r) pat * 'f code -> ('a, 'r) unsafe_patwrap
 
 let modify_fun_body : 'f code -> ('a -> 'r -> 'r) code -> 'a code -> 'f code = fun c pp a ->
   let rec dec_app : Parsetree.expression -> Parsetree.expression = fun x -> match x.pexp_desc with
     | Parsetree.Pexp_fun(Nolabel, None, p, e) -> Ast_helper.Exp.fun_ Nolabel None p (dec_app e)
     | _ -> apply_fun (apply_fun (reduce_code pp) (reduce_code a)) x
-in promote_code (dec_app (reduce_code c))
+in promote_code (dec_app (reduce_code c)) 
+
+*)

--- a/list_unrolling/lib/utilities/patterns/unsafe.mli
+++ b/list_unrolling/lib/utilities/patterns/unsafe.mli
@@ -1,5 +1,3 @@
-open Codelib;;
-
 (* Unsafe first-class pattern generation *)
 
 type (_, _) unsafe_pat
@@ -7,9 +5,15 @@ type (_, _) unsafe_pat
 val unsafe_loosen : ('a, 'f, 'r) Pat.pat -> ('a, 'r) unsafe_pat
 val unsafe_tighten : ('a, 'r) unsafe_pat -> ('a, 'f, 'r) Pat.pat
 
-(* Safe-wrapped unsafe first-class pattern generation *)
+(* Safe-wrapped unsafe first-class pattern generation
 
-type ('a, 'r) unsafe_patwrap = Pat : ('a list, 'f, 'r) Pat.pat * 'f code -> ('a, 'r) unsafe_patwrap
+This unsafe approach is not possible without near-complete redesign after migration to the (=>) operator taking an 'f
+instead of an 'f code, as the inner expression can no longer be unsafely accessed without applying values to the built
+up function .
+
+type ('a, 'r) unsafe_patwrap = UPat : ('a list, 'f, 'r code) Pat.pat * 'f code -> ('a, 'r) unsafe_patwrap
 
 (* PRECONDITION: 'f is some function of type 'a_1 -> ... -> 'a_n -> 'r *)
-val modify_fun_body : 'f code -> ('a -> 'r -> 'r) code -> 'a code -> 'f code
+val modify_fun_body : 'f code -> ('a code -> ('r -> 'r) code) -> 'a code -> 'f code
+
+*)


### PR DESCRIPTION
Modify type of `(=>)` from `('a, 'f, 'r) pat -> 'f code -> ('a, 'r) case` to `('a, 'f, 'r code) pat -> 'f -> ('a, 'r) case`. This "open" code style metaprogramming, made possible with heterogenous sequences (continuation-style), removes the need for an unsafe `apply_fun` AST rewrite function.